### PR TITLE
Feature: Support npm packages

### DIFF
--- a/app/assets/javascripts/package_form_validation.js
+++ b/app/assets/javascripts/package_form_validation.js
@@ -1,0 +1,19 @@
+(function() {
+  const validatePackages = () => {
+    let textareas = Array.from(document.querySelectorAll('.js-package-form'));
+
+    if ( textareas.every(isTextareaEmpty) ) {
+      alert('Require at least 1 package');
+      return false;
+    } else {
+      return true;
+    }
+  };
+
+  const isTextareaEmpty = (area) => {
+    let text = area.value.trim();
+    return text.length === 0;
+  };
+
+  window.validatePackages = validatePackages;
+}());

--- a/app/helpers/packages_helper.rb
+++ b/app/helpers/packages_helper.rb
@@ -1,0 +1,12 @@
+module PackagesHelper
+  def icon(package)
+    case package.registry
+    when 'rubygems'
+      'far fa-gem'
+    when 'npm'
+      'fab fa-npm'
+    else
+      raise NotImplementedError
+    end
+  end
+end

--- a/app/views/layouts/_navigation.html.erb
+++ b/app/views/layouts/_navigation.html.erb
@@ -13,7 +13,7 @@
             <span class="navbar-item">
               <a class="button is-black is-inverted" href="https://github.com/meganemura/pkgstatus">
                 <span class="icon">
-                  <i class="fa fa-lg fa-github"></i>
+                  <i class="fab fa-lg fa-github"></i>
                 </span>
                 <span>pkgstatus</span>
               </a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= javascript_include_tag 'application' %>
     <link href="https://fonts.googleapis.com/css?family=Lato:700i" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.6.2/css/bulma.css" />
-    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css">
+    <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.0.13/css/all.css" integrity="sha384-DNOHZ68U8hZfKXOrtjWvjxusGo9WQnrNx2sqG0tfsghAvtVlRW3tvkXWZh58N9jp" crossorigin="anonymous">
     <meta name="viewport" content="width=device-width,initial-scale=1">
   </head>
 

--- a/app/views/projects/_package.html.erb
+++ b/app/views/projects/_package.html.erb
@@ -11,7 +11,7 @@
             <small>
               <span class="tag">
               <a href="<%= package.registry_url %>">
-                <i class="fa fa-diamond" aria-hidden="true"></i>
+                <i class="far fa-gem" aria-hidden="true"></i>
                 <%= package.registry %>
               </a>
               </span>
@@ -22,7 +22,7 @@
               <%- if package.repository_url -%>
               <span class="tag">
               <a href="<%= package.repository_url %>">
-                <i class="fa fa-github" aria-hidden="true"></i>
+                <i class="fab fa-github" aria-hidden="true"></i>
                 GitHub
               </a>
               </span>
@@ -38,7 +38,7 @@
                 <%- if package.ci_url %>
                   <span class="tag">
                   <a href="<%= package.ci_url %>">
-                    <i class="fa fa-check-circle-o" aria-hidden="true"></i>
+                    <i class="far fa-check-circle" aria-hidden="true"></i>
                     CI
                     <%- versions = nil#package.send(:ci).configured_versions %>
                     <%- if versions.present? %>

--- a/app/views/projects/_package.html.erb
+++ b/app/views/projects/_package.html.erb
@@ -11,7 +11,7 @@
             <small>
               <span class="tag">
               <a href="<%= package.registry_url %>">
-                <i class="far fa-gem" aria-hidden="true"></i>
+                <i class="<%= icon(package) %>" aria-hidden="true"></i>
                 <%= package.registry %>
               </a>
               </span>

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -14,7 +14,7 @@
 </section>
 <section class="section">
 <div class="container has-text-centered">
-  <%= form_tag("/projects", method: :post) do %>
+  <%= form_tag("/projects", method: :post, onsubmit: 'return validatePackages()') do %>
   <div class="columns">
     <div class="column is-half">
       <h2 class="subtitle">
@@ -25,7 +25,7 @@
       <div class="field">
         <div class="control">
           <%- placeholder = %w(rails jekyll rubocop ...).join(" \n") -%>
-          <textarea name="packages[rubygems]" class="textarea is-medium" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
+          <textarea name="packages[rubygems]" class="textarea is-medium js-package-form" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
         </div>
       </div>
     </div>
@@ -39,7 +39,7 @@
       <div class="field">
         <div class="control">
           <%- placeholder = %w(express react lodash ...).join(" \n") -%>
-          <textarea name="packages[npm]" class="textarea is-medium" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
+          <textarea name="packages[npm]" class="textarea is-medium js-package-form" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
         </div>
       </div>
     </div>

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -17,7 +17,7 @@
   <div class="columns">
     <div class="column is-half is-offset-one-quarter">
       <h2 class="subtitle">
-        <i class="fa fa-diamond" aria-hidden="true"></i>
+        <i class="far fa-gem" aria-hidden="true"></i>
         rubygems
       </h2>
 

--- a/app/views/top_pages/index.html.erb
+++ b/app/views/top_pages/index.html.erb
@@ -14,29 +14,43 @@
 </section>
 <section class="section">
 <div class="container has-text-centered">
+  <%= form_tag("/projects", method: :post) do %>
   <div class="columns">
-    <div class="column is-half is-offset-one-quarter">
+    <div class="column is-half">
       <h2 class="subtitle">
         <i class="far fa-gem" aria-hidden="true"></i>
         rubygems
       </h2>
 
-      <%= form_tag("/projects", method: :post) do %>
       <div class="field">
         <div class="control">
           <%- placeholder = %w(rails jekyll rubocop ...).join(" \n") -%>
-          <textarea name="packages" class="textarea is-medium" type="text" placeholder="<%= placeholder %>" rows="10" required></textarea>
+          <textarea name="packages[rubygems]" class="textarea is-medium" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
         </div>
       </div>
+    </div>
 
-      <div class="has-text-centered">
-        <button class="button is-medium" type="submit">
-          Create a new project
-        </button>
+    <div class="column is-half">
+      <h2 class="subtitle">
+        <i class="fab fa-npm" aria-hidden="true"></i>
+        npm
+      </h2>
+
+      <div class="field">
+        <div class="control">
+          <%- placeholder = %w(express react lodash ...).join(" \n") -%>
+          <textarea name="packages[npm]" class="textarea is-medium" type="text" placeholder="<%= placeholder %>" rows="10"></textarea>
+        </div>
       </div>
-      <%- end -%>
     </div>
   </div>
+
+  <div class="has-text-centered">
+    <button class="button is-medium" type="submit">
+      Create a new project
+    </button>
+  </div>
+  <%- end -%>
   <div>
     <small>
       <a href="https://gist.github.com/meganemura/43deff5c80283e58e932a0617525d6d9">


### PR DESCRIPTION
Hi!

This PR enables users to check npm package statuses as well as rubygems.

(demo)
![pkgstatus-supports-npm](https://user-images.githubusercontent.com/1162665/40122184-2f5e117e-595e-11e8-8d04-d2cd348fb13f.gif)

This PR does:

- Add a form for npm to the top page, and make the project controller receive npm package data.
- Bump up Font Awesome to 5 in order to display a npm icon.
- Validate whether or not top page forms are empty using JavaScript instead of html input required attributes.
- Add validations of npm package naming.

I would appreciate receiving a feedback.